### PR TITLE
Enable AS3 Externs and add support for MXML

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "16"
-      - run: npm ci
-      - run: npm run build
+          node-version: "18"
+      - run: npm ci && npm i -g @apache-royale/royale-js
+      - run: npm run build && npm run build-swc
       - run: npm pack
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "18"
-      - run: npm ci && npm i -g @apache-royale/royale-js
-      - run: npm run build && npm run build-swc
+      - run: npm ci
+      - run: npm run build
       - run: npm pack
       - uses: actions/upload-artifact@v4
         with:

--- a/npm-scripts/AS3ExternsGenerator.hx
+++ b/npm-scripts/AS3ExternsGenerator.hx
@@ -216,10 +216,6 @@ class AS3ExternsGenerator {
 		if (options != null && options.vectorEmulationClass != null && qname == QNAME_VECTOR) {
 			return false;
 		}
-		if ((options == null || options.renameSymbols == null || options.renameSymbols.indexOf(qname) == -1)
-				&& baseType.meta.has(":noCompletion")) {
-			return true;
-		}
 		if (options != null) {
 			if (options.includedPackages != null) {
 				final qnameLastDotIndex = qname.lastIndexOf(".");
@@ -270,7 +266,7 @@ class AS3ExternsGenerator {
 		result.add(' {\n');
 		result.add(generateClassTypeImports(classType));
 		result.add(generateDocs(classType.doc, true, ""));
-		result.add(generateMetadata(classType.meta.get(), ""));
+		result.add(generateMetadata(classType.meta.get(), "", classType));
 		var className = baseTypeToUnqualifiedName(classType, params, false);
 		result.add('public class $className');
 		var includeFieldsFrom:ClassType = null;
@@ -690,7 +686,7 @@ class AS3ExternsGenerator {
 		result.add(' {\n');
 		result.add(generateClassTypeImports(interfaceType));
 		result.add(generateDocs(interfaceType.doc, true, ""));
-		result.add(generateMetadata(interfaceType.meta.get(), ""));
+		result.add(generateMetadata(interfaceType.meta.get(), "", interfaceType));
 		var interfaceName = baseTypeToUnqualifiedName(interfaceType, params, false);
 		result.add('public interface ${interfaceName}');
 		var interfaces = interfaceType.interfaces;
@@ -895,7 +891,7 @@ class AS3ExternsGenerator {
 		return result.toString();
 	}
 
-	private function generateMetadata(metadata:Metadata, indent:String):String {
+	private function generateMetadata(metadata:Metadata, indent:String, classType:Null<ClassType> = null):String {
 		var result = new StringBuf();
 		for (meta in metadata) {
 			if (METADATA_TO_REWRITE.exists(meta.name)) {
@@ -991,6 +987,43 @@ class AS3ExternsGenerator {
 			}
 		}
 
+		// Add [ExcludeClass] and [Exclude] metadata tags
+		if(classType != null)
+		{
+			if(classType.meta.has(":noCompletion")) result.add('$indent[ExcludeClass]');
+			var includeFieldsFrom:ClassType = null;
+			while (includeFieldsFrom != null) {
+				for (classField in includeFieldsFrom.fields.get()) {
+					if(classField.meta.has(":noCompletion") && classField.isPublic)
+					{
+						var fieldName = classField.name;
+						var kind = macroTypeToExcludeKind(classField.type);
+						result.add('$indent[Exclude(name = "$fieldName", kind="$kind")]\n');
+					}
+				}
+				if (includeFieldsFrom.superClass == null) {
+					break;
+				}
+				includeFieldsFrom = includeFieldsFrom.superClass.t.get();
+			}
+			for (classField in classType.statics.get()) {
+				if(classField.meta.has(":noCompletion") && classField.isPublic)
+					{
+						var fieldName = classField.name;
+						var kind = macroTypeToExcludeKind(classField.type);
+						result.add('$indent[Exclude(name = "$fieldName", kind="$kind")]\n');
+					}
+			}
+			for (classField in classType.fields.get()) {
+				if(classField.meta.has(":noCompletion") && classField.isPublic)
+					{
+						var fieldName = classField.name;
+						var kind = macroTypeToExcludeKind(classField.type);
+						result.add('$indent[Exclude(name = "$fieldName", kind="$kind")]\n');
+					}
+			}
+		}
+
 		return result.toString();
 	}
 
@@ -998,7 +1031,6 @@ class AS3ExternsGenerator {
 		if (classField.name != "new") {
 			if (!classField.isPublic
 				|| classField.isExtern
-				|| classField.meta.has(":noCompletion")
 				|| DISALLOWED_AS3_NAMES.indexOf(classField.name) != -1) {
 				return true;
 			}
@@ -1151,6 +1183,14 @@ class AS3ExternsGenerator {
 			}
 		}
 		return "*";
+	}
+
+	private function macroTypeToExcludeKind(type:Type, includeParams:Bool = true):String {
+		var qname = macroTypeToQname(type, includeParams);
+		if(qname == "Function")
+			return "method";
+		else
+			return "property";
 	}
 
 	private function rewriteQname(qname:String):String {

--- a/npm-scripts/AS3ExternsGenerator.hx
+++ b/npm-scripts/AS3ExternsGenerator.hx
@@ -40,7 +40,7 @@ class AS3ExternsGenerator {
 		"bindable" 		      => "Bindable",
 		"event" 			  => "Event",
 		"inspectable" 		  => "Inspectable",
-		"defaultXmlProperty"  => "DefaultProperty"
+		"defaultXmlProperty"  => "DefaultProperty",
 		":bindable" 		  => "Bindable",
 		":event" 			  => "Event",
 		":inspectable" 		  => "Inspectable",

--- a/npm-scripts/AS3ExternsGenerator.hx
+++ b/npm-scripts/AS3ExternsGenerator.hx
@@ -37,10 +37,14 @@ class AS3ExternsGenerator {
 		"Void" => "void"
 	];
 	private static final METADATA_TO_REWRITE:Map<String, String> = [
-		":bindable" 		 => "Bindable",
-		":event" 			 => "Event",
-		":inspectable" 		 => "Inspectable",
-		"defaultXmlProperty" => "DefaultProperty"
+		"bindable" 		      => "Bindable",
+		"event" 			  => "Event",
+		"inspectable" 		  => "Inspectable",
+		"defaultXmlProperty"  => "DefaultProperty"
+		":bindable" 		  => "Bindable",
+		":event" 			  => "Event",
+		":inspectable" 		  => "Inspectable",
+		":defaultXmlProperty" => "DefaultProperty"
 	];
 	private static final QNAME_VECTOR = "Vector";
 

--- a/npm-scripts/AS3ExternsGenerator.hx
+++ b/npm-scripts/AS3ExternsGenerator.hx
@@ -35,6 +35,7 @@ class AS3ExternsGenerator {
 		"UInt" => "uint",
 		"Void" => "void"
 	];
+	private static final QNAME_VECTOR = "Vector";
 
 	public static function generate(?options:AS3GeneratorOptions):Void {
 		var outputDirPath = Path.join([Path.directory(Compiler.getOutput()), "as3-externs"]);
@@ -51,6 +52,7 @@ class AS3ExternsGenerator {
 	}
 
 	private var options:AS3GeneratorOptions;
+	private var _skipVectorEmulationClass:Bool = false;
 
 	private function new(?options:AS3GeneratorOptions) {
 		this.options = options;
@@ -58,11 +60,18 @@ class AS3ExternsGenerator {
 
 	public function generateForTypes(types:Array<Type>, outputDirPath:String):Void {
 		for (type in types) {
+			var prevSkipVectorEmulationClass = _skipVectorEmulationClass;
 			switch (type) {
 				case TInst(t, params):
 					var classType = t.get();
 					if (shouldSkipBaseType(classType, false)) {
 						continue;
+					}
+					var qname = baseTypeToQname(classType, params, false);
+					if (qname == QNAME_VECTOR) {
+						// when we generate the vector emulation class,
+						// temporarily stop treating it as AS3 Vector.
+						_skipVectorEmulationClass = true;
 					}
 					if (classType.isInterface) {
 						var generated = generateInterface(classType, params);
@@ -94,6 +103,7 @@ class AS3ExternsGenerator {
 				default:
 					trace("Unexpected type: " + type);
 			}
+			_skipVectorEmulationClass = prevSkipVectorEmulationClass;
 		}
 	}
 
@@ -136,10 +146,8 @@ class AS3ExternsGenerator {
 					switch (classType.kind) {
 						case KTypeParameter(constraints):
 							var typeParamSourceQname = classType.pack.join(".");
-							if (QNAMES_TO_REWRITE.exists(typeParamSourceQname)) {
-								typeParamSourceQname = QNAMES_TO_REWRITE.get(typeParamSourceQname);
-							}
-							if (typeParamSourceQname == "Vector")
+							typeParamSourceQname = rewriteQname(typeParamSourceQname);
+							if (typeParamSourceQname == QNAME_VECTOR)
 							{
 								// don't let Vector.<T> become Vector.<*>
 								return false;
@@ -198,6 +206,9 @@ class AS3ExternsGenerator {
 			return true;
 		}
 		final qname = baseTypeToQname(baseType, [], false);
+		if (options != null && options.vectorEmulationClass != null && qname == QNAME_VECTOR) {
+			return false;
+		}
 		if ((options == null || options.renameSymbols == null || options.renameSymbols.indexOf(qname) == -1)
 				&& baseType.meta.has(":noCompletion")) {
 			return true;
@@ -972,10 +983,8 @@ class AS3ExternsGenerator {
 					switch (classType.kind) {
 						case KTypeParameter(constraints):
 							var typeParamSourceQname = classType.pack.join(".");
-							if (QNAMES_TO_REWRITE.exists(typeParamSourceQname)) {
-								typeParamSourceQname = QNAMES_TO_REWRITE.get(typeParamSourceQname);
-							}
-							if (typeParamSourceQname == "Vector")
+							typeParamSourceQname = rewriteQname(typeParamSourceQname);
+							if (typeParamSourceQname == QNAME_VECTOR)
 							{
 								return baseTypeToQname(classType, defTypeParams != null ? defTypeParams : params, includeParams);
 							}
@@ -1031,6 +1040,54 @@ class AS3ExternsGenerator {
 		return "*";
 	}
 
+	private function rewriteQname(qname:String):String {
+		if (options != null) {
+			if (options.renamePackages != null) {
+				var renamePackages = options.renamePackages;
+				var i = 0;
+				while (i < renamePackages.length) {
+					var originalName = renamePackages[i];
+					if (originalName.indexOf(".") != -1) {
+						throw "renamePackages is available for top-level packages only";
+					}
+					i++;
+					var newName = renamePackages[i];
+					i++;
+					if (StringTools.startsWith(qname, originalName + ".")) {
+						qname = newName + "." + qname.substr(originalName.length + 1);
+						break;
+					}
+				}
+			}
+			if (options.renameSymbols != null) {
+				var renameSymbols = options.renameSymbols;
+				var i = 0;
+				while (i < renameSymbols.length) {
+					var originalName = renameSymbols[i];
+					i++;
+					var newName = renameSymbols[i];
+					i++;
+					if (originalName == qname) {
+						qname = newName;
+						break;
+					}
+				}
+			}
+			if (!_skipVectorEmulationClass && options.vectorEmulationClass != null) {
+				var vectorEmulationClass = options.vectorEmulationClass;
+				if (qname == vectorEmulationClass) {
+					qname = QNAME_VECTOR; 
+				}
+			}
+		}
+
+		if (QNAMES_TO_REWRITE.exists(qname)) {
+			qname = QNAMES_TO_REWRITE.get(qname);
+		}
+
+		return qname;
+	}
+
 	private function baseTypeToQname(baseType:BaseType, params:Array<Type>, includeParams:Bool = true):String {
 		if (baseType == null) {
 			return "*";
@@ -1042,26 +1099,9 @@ class AS3ExternsGenerator {
 		}
 		buffer.add(baseType.name);
 		var qname = buffer.toString();
-		if (options != null && options.renameSymbols != null) {
-			var renameSymbols = options.renameSymbols;
-			var i = 0;
-			while (i < renameSymbols.length) {
-				var originalName = renameSymbols[i];
-				i++;
-				var newName = renameSymbols[i];
-				i++;
-				if (originalName == qname) {
-					qname = newName;
-					break;
-				}
-			}
-		}
+		qname = rewriteQname(qname);
 
-		if (QNAMES_TO_REWRITE.exists(qname)) {
-			qname = QNAMES_TO_REWRITE.get(qname);
-		}
-
-		if (!includeParams || params.length == 0 || qname != "Vector") {
+		if (!includeParams || params.length == 0 || qname != QNAME_VECTOR) {
 			return qname;
 		}
 
@@ -1076,27 +1116,7 @@ class AS3ExternsGenerator {
 			return "*";
 		}
 		var qname = baseTypeToQname(baseType, params, false);
-		if (qname == "*") {
-			return qname;
-		}
-		if (options != null && options.renameSymbols != null) {
-			var renameSymbols = options.renameSymbols;
-			var i = 0;
-			while (i < renameSymbols.length) {
-				var originalName = renameSymbols[i];
-				i++;
-				var newName = renameSymbols[i];
-				i++;
-				if (originalName == qname) {
-					qname = newName;
-					break;
-				}
-			}
-		}
-
-		if (QNAMES_TO_REWRITE.exists(qname)) {
-			qname = QNAMES_TO_REWRITE.get(qname);
-		}
+		qname = rewriteQname(qname);
 
 		var unqualifiedName = qname;
 		var index = unqualifiedName.lastIndexOf(".");
@@ -1104,7 +1124,7 @@ class AS3ExternsGenerator {
 			unqualifiedName = unqualifiedName.substr(index + 1);
 		}
 
-		if (!includeParams || params.length == 0 || qname != "Vector") {
+		if (!includeParams || params.length == 0 || qname != QNAME_VECTOR) {
 			return unqualifiedName;
 		}
 
@@ -1175,9 +1195,7 @@ class AS3ExternsGenerator {
 				switch (classType.kind) {
 					case KTypeParameter(constraints):
 						var typeParamSourceQname = classType.pack.join(".");
-						if (QNAMES_TO_REWRITE.exists(typeParamSourceQname)) {
-							typeParamSourceQname = QNAMES_TO_REWRITE.get(typeParamSourceQname);
-						}
+						typeParamSourceQname = rewriteQname(typeParamSourceQname);
 						if (typeParamSourceQname == typeParametersQname) {
 							for (j in 0...typeParameters.length) {
 								var param = typeParameters[j];
@@ -1281,5 +1299,16 @@ typedef AS3GeneratorOptions = {
 	/**
 		The target directory where externs files will be generated.
 	**/
-	?outputPath:String
+	?outputPath:String,
+
+	/**
+		Specify a class that will be used for Vector emulation.
+	**/
+	?vectorEmulationClass:String,
+
+	/**
+		Gives specific top-level packages new names. Alternates between the
+		original package name and its new name.
+	**/
+	?renamePackages:Array<String>
 }

--- a/npm-scripts/AS3ExternsGenerator.hx
+++ b/npm-scripts/AS3ExternsGenerator.hx
@@ -6,6 +6,7 @@ import haxe.macro.Type;
 import haxe.macro.Type.BaseType;
 import haxe.macro.Type.AbstractType;
 import haxe.macro.Context;
+import haxe.macro.Expr.Metadata;
 
 class AS3ExternsGenerator {
 	private static final ALWAYS_ALLOWED_REFERENCE_TYPES = [
@@ -34,6 +35,12 @@ class AS3ExternsGenerator {
 		"Int" => "int",
 		"UInt" => "uint",
 		"Void" => "void"
+	];
+	private static final METADATA_TO_REWRITE:Map<String, String> = [
+		":bindable" 		 => "Bindable",
+		":event" 			 => "Event",
+		":inspectable" 		 => "Inspectable",
+		"defaultXmlProperty" => "DefaultProperty"
 	];
 	private static final QNAME_VECTOR = "Vector";
 
@@ -263,6 +270,7 @@ class AS3ExternsGenerator {
 		result.add(' {\n');
 		result.add(generateClassTypeImports(classType));
 		result.add(generateDocs(classType.doc, true, ""));
+		result.add(generateMetadata(classType.meta.get(), ""));
 		var className = baseTypeToUnqualifiedName(classType, params, false);
 		result.add('public class $className');
 		var includeFieldsFrom:ClassType = null;
@@ -353,6 +361,7 @@ class AS3ExternsGenerator {
 			interfaces:Array<{t:Ref<ClassType>, params:Array<Type>}>):String {
 		var result = new StringBuf();
 		result.add(generateDocs(classField.doc, false, "\t"));
+		result.add(generateMetadata(classField.meta.get(), "\t"));
 		result.add("\t");
 		var superClassType:ClassType = null;
 		var skippedSuperClass = false;
@@ -681,6 +690,7 @@ class AS3ExternsGenerator {
 		result.add(' {\n');
 		result.add(generateClassTypeImports(interfaceType));
 		result.add(generateDocs(interfaceType.doc, true, ""));
+		result.add(generateMetadata(interfaceType.meta.get(), ""));
 		var interfaceName = baseTypeToUnqualifiedName(interfaceType, params, false);
 		result.add('public interface ${interfaceName}');
 		var interfaces = interfaceType.interfaces;
@@ -713,6 +723,7 @@ class AS3ExternsGenerator {
 	private function generateInterfaceField(interfaceField:ClassField):String {
 		var result = new StringBuf();
 		result.add(generateDocs(interfaceField.doc, false, "\t"));
+		result.add(generateMetadata(interfaceField.meta.get(), "\t"));
 		result.add("\t");
 		switch (interfaceField.kind) {
 			case FMethod(k):
@@ -791,6 +802,7 @@ class AS3ExternsGenerator {
 		}
 		result.add(' {\n');
 		result.add(generateDocs(enumType.doc, true, ""));
+		result.add(generateMetadata(enumType.meta.get(), ""));
 		var enumName = baseTypeToUnqualifiedName(enumType, params, false);
 		result.add('public class ${enumName}');
 		result.add(' {\n');
@@ -805,6 +817,7 @@ class AS3ExternsGenerator {
 	private function generateEnumField(enumField:EnumField, enumType:EnumType, enumTypeParams:Array<Type>):String {
 		var result = new StringBuf();
 		result.add(generateDocs(enumField.doc, false, "\t"));
+		result.add(generateMetadata(enumField.meta.get(), "\t"));
 		result.add("\t");
 		result.add('public static ');
 		result.add('const ');
@@ -827,6 +840,7 @@ class AS3ExternsGenerator {
 		}
 		result.add(' {\n');
 		result.add(generateDocs(abstractType.doc, true, ""));
+		result.add(generateMetadata(abstractType.meta.get(), ""));
 		var abstractName = baseTypeToUnqualifiedName(abstractType, params, false);
 		result.add('public class ${abstractName}');
 		result.add(' {\n');
@@ -878,6 +892,105 @@ class AS3ExternsGenerator {
 			result.add('$indent * @externs\n');
 		}
 		result.add('$indent */\n');
+		return result.toString();
+	}
+
+	private function generateMetadata(metadata:Metadata, indent:String):String {
+		var result = new StringBuf();
+		for (meta in metadata) {
+			if (METADATA_TO_REWRITE.exists(meta.name)) {
+				var metadataName = METADATA_TO_REWRITE.get(meta.name);
+				var hasParams:Bool = (meta.params != null && meta.params.length > 0);
+
+				result.add('$indent[$metadataName');
+
+				var addArgsAfter = false;
+				var args = new Array<String>();
+
+				if (hasParams) {
+					result.add('(');
+					for (param in meta.params) {
+						addArgsAfter = false;
+						// trace(param.expr);
+						switch (param.expr) {
+							// Bindable
+							case EConst(CString(s)):
+								result.add('"$s"');
+
+							// Event
+							case EField(e, field):
+								var field:String = field;
+								var qualifiedName:String = "";
+								switch (e.expr) {
+									case EField(e, field):
+										switch (e.expr) {
+											case EField(e, field):
+												switch (e.expr) {
+													case EConst(CIdent(s)):
+														qualifiedName = s + "." + field;
+													case _:
+												}
+											case _:
+										}
+										qualifiedName = qualifiedName + "." + field;
+									case _:
+								}
+								var type:Type = Context.getType(qualifiedName);
+								var propValue:String = "";
+								switch (type) {
+									case TInst(t, _):
+										var cls:ClassType = t.get();
+										for (f in cls.statics.get()) {
+											if (f.name == field) {
+												if (f.expr() != null) {
+													var e:TypedExpr = f.expr();
+													switch (e.expr) {
+														case TCast(t, _):
+															switch (t.expr) {
+																case TConst(TString(s)):
+																	propValue = s;
+																case _:
+															}
+														case _:
+													}
+												}
+											}
+										}
+									case _:
+								}
+								result.add('name="$propValue", type="$qualifiedName"');
+
+							// Inspectable
+							case EBinop(_, e1, e2):
+								addArgsAfter = true;
+								var prop = "";
+								var value = "";
+								switch (e1.expr) {
+									case EConst(CIdent(s)):
+										prop = s;
+									case _:
+								}
+
+								switch (e2.expr) {
+									case EConst(CString(s)):
+										value = s;
+									case _:
+								}
+								args.push('$prop = "$value"');
+
+							case _:
+						}
+					}
+
+					if (addArgsAfter) 
+						result.add(args.join(", "));
+					result.add(')');
+				}
+
+				result.add(']\n');
+			}
+		}
+
 		return result.toString();
 	}
 

--- a/npm-scripts/TSExternsGenerator.hx
+++ b/npm-scripts/TSExternsGenerator.hx
@@ -1329,17 +1329,7 @@ class TSExternsGenerator {
 		return "any";
 	}
 
-	private function baseTypeToQname(baseType:BaseType, params:Array<Type>, includeParams:Bool = true):String {
-		if (baseType == null) {
-			return "any";
-		}
-		var buffer = new StringBuf();
-		if (baseType.pack.length > 0) {
-			buffer.add(baseType.pack.join("."));
-			buffer.add(".");
-		}
-		buffer.add(baseType.name);
-		var qname = buffer.toString();
+	private function rewriteQname(qname:String):String {
 		if (options != null && options.renameSymbols != null) {
 			var renameSymbols = options.renameSymbols;
 			var i = 0;
@@ -1358,6 +1348,22 @@ class TSExternsGenerator {
 		if (QNAMES_TO_REWRITE.exists(qname)) {
 			qname = QNAMES_TO_REWRITE.get(qname);
 		}
+
+		return qname;
+	}
+
+	private function baseTypeToQname(baseType:BaseType, params:Array<Type>, includeParams:Bool = true):String {
+		if (baseType == null) {
+			return "any";
+		}
+		var buffer = new StringBuf();
+		if (baseType.pack.length > 0) {
+			buffer.add(baseType.pack.join("."));
+			buffer.add(".");
+		}
+		buffer.add(baseType.name);
+		var qname = buffer.toString();
+		qname = rewriteQname(qname);
 
 		if (!includeParams || params.length == 0) {
 			return qname;
@@ -1374,26 +1380,9 @@ class TSExternsGenerator {
 			return "any";
 		}
 		var qname = baseTypeToQname(baseType, params, false);
+		qname = rewriteQname(qname);
 		if (qname == "any") {
 			return qname;
-		}
-		if (options != null && options.renameSymbols != null) {
-			var renameSymbols = options.renameSymbols;
-			var i = 0;
-			while (i < renameSymbols.length) {
-				var originalName = renameSymbols[i];
-				i++;
-				var newName = renameSymbols[i];
-				i++;
-				if (originalName == qname) {
-					qname = newName;
-					break;
-				}
-			}
-		}
-
-		if (QNAMES_TO_REWRITE.exists(qname)) {
-			qname = QNAMES_TO_REWRITE.get(qname);
 		}
 
 		var foundImportMapping = false;

--- a/npm-scripts/js-lib.hxml
+++ b/npm-scripts/js-lib.hxml
@@ -24,6 +24,6 @@
 --remap flash:openfl
 --macro JSPropertiesMacro.defineProperties()
 --macro PatchMacro.applyPatch()
---macro AS3ExternsGenerator.generate({outputPath: "../lib", includedPackages: ["feathers"], allowedPackageReferences: ["openfl"], renameSymbols: ["openfl.VectorData", "openfl.Vector", "openfl.utils.ByteArrayData", "openfl.utils.ByteArray"]})
+--macro AS3ExternsGenerator.generate({outputPath: "../lib", includedPackages: ["feathers"], allowedPackageReferences: ["openfl"], renameSymbols: ["openfl.VectorData", "openfl.Vector", "openfl.utils.ByteArrayData", "openfl.utils.ByteArray"], excludeSymbols: ["feathers.motion.effects.actuate.SimpleEffectActuator", "feathers.motion.effects.actuate.MethodEffectActuator"]})
 --macro TSExternsGenerator.generate({outputPath: "../lib", includedPackages: ["feathers"], allowedPackageReferences: ["openfl"], renameSymbols: ["openfl.VectorData", "openfl.Vector", "openfl.utils.ByteArrayData", "openfl.utils.ByteArray"]})
 --no-inline

--- a/npm-scripts/mxml-manifest.xml
+++ b/npm-scripts/mxml-manifest.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0"?>
+
+<!--
+
+    Feathers UI Components
+
+-->
 <componentPackage>
   <component id="ActivityIndicator" class="feathers.controls.ActivityIndicator"/>
   <component id="Application" class="feathers.controls.Application"/>

--- a/npm-scripts/mxml-manifest.xml
+++ b/npm-scripts/mxml-manifest.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+<componentPackage>
+  <component id="ActivityIndicator" class="feathers.controls.ActivityIndicator"/>
+  <component id="Application" class="feathers.controls.Application"/>
+  <component id="AssetLoader" class="feathers.controls.AssetLoader"/>
+  <component id="BasicButton" class="feathers.controls.BasicButton"/>
+  <component id="Button" class="feathers.controls.Button"/>
+  <component id="ButtonBar" class="feathers.controls.ButtonBar"/>
+  <component id="Callout" class="feathers.controls.Callout"/>
+  <component id="Check" class="feathers.controls.Check"/>
+  <component id="Collapsible" class="feathers.controls.Collapsible"/>
+  <component id="ComboBox" class="feathers.controls.ComboBox"/>
+  <component id="DatePicker" class="feathers.controls.DatePicker"/>
+  <component id="Drawer" class="feathers.controls.Drawer"/>
+  <component id="Form" class="feathers.controls.Form"/>
+  <component id="FormItem" class="feathers.controls.FormItem"/>
+  <component id="GridView" class="feathers.controls.GridView"/>
+  <component id="GridViewColumn" class="feathers.controls.GridViewColumn"/>
+  <component id="GroupListView" class="feathers.controls.GroupListView"/>
+  <component id="HDividedBox" class="feathers.controls.HDividedBox"/>
+  <component id="Header" class="feathers.controls.Header"/>
+  <component id="HProgressBar" class="feathers.controls.HProgressBar"/>
+  <component id="HScrollBar" class="feathers.controls.HScrollBar"/>
+  <component id="HSlider" class="feathers.controls.HSlider"/>
+  <component id="Label" class="feathers.controls.Label"/>
+  <component id="LayoutGroup" class="feathers.controls.LayoutGroup"/>
+  <component id="ListView" class="feathers.controls.ListView"/>
+  <component id="NumericStepper" class="feathers.controls.NumericStepper"/>
+  <component id="PageIndicator" class="feathers.controls.PageIndicator"/>
+  <component id="Panel" class="feathers.controls.Panel"/>
+  <component id="PopUpDatePicker" class="feathers.controls.PopUpDatePicker"/>
+  <component id="PopUpListView" class="feathers.controls.PopUpListView"/>
+  <component id="Radio" class="feathers.controls.Radio"/>
+  <component id="ScrollContainer" class="feathers.controls.ScrollContainer"/>
+  <component id="TabBar" class="feathers.controls.TabBar"/>
+  <component id="TextArea" class="feathers.controls.TextArea"/>
+  <component id="TextCallout" class="feathers.controls.TextCallout"/>
+  <component id="TextInput" class="feathers.controls.TextInput"/>
+  <component id="ToggleButton" class="feathers.controls.ToggleButton"/>
+  <component id="ToggleButtonState" class="feathers.controls.ToggleButtonState"/>
+  <component id="ToggleSwitch" class="feathers.controls.ToggleSwitch"/>
+  <component id="TreeGridView" class="feathers.controls.TreeGridView"/>
+  <component id="TreeGridViewColumn" class="feathers.controls.TreeGridViewColumn"/>
+  <component id="TreeView" class="feathers.controls.TreeView"/>
+  <component id="VDividedBox" class="feathers.controls.VDividedBox"/>
+  <component id="VProgressBar" class="feathers.controls.VProgressBar"/>
+  <component id="VScrollBar" class="feathers.controls.VScrollBar"/>
+  <component id="VSlider" class="feathers.controls.VSlider"/>
+
+  <component id="HierarchicalItemRenderer" class="feathers.controls.dataRenderers.HierarchicalItemRenderer"/>
+  <component id="ItemRenderer" class="feathers.controls.dataRenderers.ItemRenderer"/>
+  <component id="LayoutGroupItemRenderer" class="feathers.controls.dataRenderers.LayoutGroupItemRenderer"/>
+  <component id="SortOrderHeaderRenderer" class="feathers.controls.dataRenderers.SortOrderHeaderRenderer"/>
+
+  <component id="PageNavigator" class="feathers.controls.navigators.PageNavigator"/>
+  <component id="RouterNavigator" class="feathers.controls.navigators.RouterNavigator"/>
+  <component id="StackNavigator" class="feathers.controls.navigators.StackNavigator"/>
+  <component id="TabNavigator" class="feathers.controls.navigators.TabNavigator"/
+
+  <component id="CalloutPopUpAdapter" class="feathers.controls.popups.CalloutPopUpAdapter"/>
+  <component id="DropDownPopUpAdapter" class="feathers.controls.popups.DropDownPopUpAdapter"/>
+
+  <component id="ArrayCollection" class="feathers.data.ArrayCollection"/>
+  <component id="ArrayHierarchicalCollection" class="feathers.data.ArrayHierarchicalCollection"/>
+
+  <component id="FillStyle" class="feathers.graphics.FillStyle"/>
+  <component id="LineStyle" class="feathers.graphics.LineStyle"/>
+  <component id="GradientBoxTransform" class="feathers.graphics.GradientBoxTransform"/>
+
+  <component id="AnchorLayout" class="feathers.layout.AnchorLayout"/>
+  <component id="AnchorLayoutData" class="feathers.layout.AnchorLayoutData"/>
+  <component id="Anchor" class="feathers.layout.AnchorLayout.Anchor"/>
+  <component id="FlowRowsLayout" class="feathers.layout.FlowRowsLayout"/>
+  <component id="HorizontalDistributedLayout" class="feathers.layout.HorizontalDistributedLayout"/>
+  <component id="HorizontalLayout" class="feathers.layout.HorizontalLayout"/>
+  <component id="HorizontalLayoutData" class="feathers.layout.HorizontalLayoutData"/>
+  <component id="HorizontalListLayout" class="feathers.layout.HorizontalListLayout"/>
+  <component id="PagedTiledRowsListLayout" class="feathers.layout.PagedTiledRowsListLayout"/>
+  <component id="ResponsiveGridLayout" class="feathers.layout.ResponsiveGridLayout"/>
+  <component id="ResponsiveGridLayoutData" class="feathers.layout.ResponsiveGridLayoutData"/>
+  <component id="TiledRowsLayout" class="feathers.layout.TiledRowsLayout"/>
+  <component id="TiledRowsListLayout" class="feathers.layout.TiledRowsListLayout"/>
+  <component id="VerticalDistributedLayout" class="feathers.layout.VerticalDistributedLayout"/>
+  <component id="VerticalLayout" class="feathers.layout.VerticalLayout"/>
+  <component id="VerticalLayoutData" class="feathers.layout.VerticalLayoutData"/>
+  <component id="VerticalListFixedRowLayout" class="feathers.layout.VerticalListFixedRowLayout"/>
+  <component id="VerticalListLayout" class="feathers.layout.VerticalListLayout"/>
+
+  <component id="ButtonMultiSkin" class="feathers.skins.ButtonMultiSkin"/>
+  <component id="CircleSkin" class="feathers.skins.CircleSkin"/>
+  <component id="DonutSkin" class="feathers.skins.DonutSkin"/>
+  <component id="EllipseSkin" class="feathers.skins.EllipseSkin"/>
+  <component id="HorizontalLineSkin" class="feathers.skins.HorizontalLineSkin"/>
+  <component id="LeftAndRightBorderSkin" class="feathers.skins.LeftAndRightBorderSkin"/>
+  <component id="MultiSkin" class="feathers.skins.MultiSkin"/>
+  <component id="PillSkin" class="feathers.skins.PillSkin"/>
+  <component id="RectangleSkin" class="feathers.skins.RectangleSkin"/>
+  <component id="TabSkin" class="feathers.skins.TabSkin"/>
+  <component id="TextInputMultiSkin" class="feathers.skins.TextInputMultiSkin"/>
+  <component id="ToggleButtonMultiSkin" class="feathers.skins.ToggleButtonMultiSkin"/>
+  <component id="TopAndBottomBorderSkin" class="feathers.skins.TopAndBottomBorderSkin"/>
+  <component id="TriangleSkin" class="feathers.skins.TriangleSkin"/>
+  <component id="UnderlineSkin" class="feathers.skins.UnderlineSkin"/>
+  <component id="VerticalLineSkin" class="feathers.skins.VerticalLineSkin"/>
+
+  <component id="DotsActivitySkin" class="feathers.skins.activity.DotsActivitySkin"/>
+
+  <component id="TextFormat" class="feathers.text.TextFormat"/>
+</componentPackage>

--- a/npm-scripts/mxml-manifest.xml
+++ b/npm-scripts/mxml-manifest.xml
@@ -75,7 +75,7 @@
 
   <component id="AnchorLayout" class="feathers.layout.AnchorLayout"/>
   <component id="AnchorLayoutData" class="feathers.layout.AnchorLayoutData"/>
-  <component id="Anchor" class="feathers.layout.AnchorLayout.Anchor"/>
+  <component id="Anchor" class="feathers.layout.Anchor"/>
   <component id="FlowRowsLayout" class="feathers.layout.FlowRowsLayout"/>
   <component id="HorizontalDistributedLayout" class="feathers.layout.HorizontalDistributedLayout"/>
   <component id="HorizontalLayout" class="feathers.layout.HorizontalLayout"/>

--- a/npm-scripts/mxml-manifest.xml
+++ b/npm-scripts/mxml-manifest.xml
@@ -61,7 +61,7 @@
   <component id="PageNavigator" class="feathers.controls.navigators.PageNavigator"/>
   <component id="RouterNavigator" class="feathers.controls.navigators.RouterNavigator"/>
   <component id="StackNavigator" class="feathers.controls.navigators.StackNavigator"/>
-  <component id="TabNavigator" class="feathers.controls.navigators.TabNavigator"/
+  <component id="TabNavigator" class="feathers.controls.navigators.TabNavigator"/>
 
   <component id="CalloutPopUpAdapter" class="feathers.controls.popups.CalloutPopUpAdapter"/>
   <component id="DropDownPopUpAdapter" class="feathers.controls.popups.DropDownPopUpAdapter"/>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gen-lib": "cd npm-scripts && node generate-modules gen-lib",
     "build-lib": "cd npm-scripts && haxe js-lib.hxml && node generate-modules fix-npm-libs && tsc",
     "build-lib-esm": "cd npm-scripts && node generate-modules gen-esm",
-    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -external-library-path+=node_modules/openfl/dist/openfl.swc -allow-subclass-overrides=true -output=dist/feathersui-royale-typedefs.swc",
+    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -external-library-path+=node_modules/openfl/dist/openfl.swc -allow-subclass-overrides=true --namespace+=https://ns.feathersui.com/mxml,npm-scripts/manifest.xml -output=dist/feathersui-royale-typedefs.swc",
     "build-dist": "npm run build-dist:dev && npm run build-dist:prod",
     "build-dist:dev": "webpack --config webpack.dev.js",
     "build-dist:prod": "webpack --config webpack.prod.js"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gen-lib": "cd npm-scripts && node generate-modules gen-lib",
     "build-lib": "cd npm-scripts && haxe js-lib.hxml && node generate-modules fix-npm-libs && tsc",
     "build-lib-esm": "cd npm-scripts && node generate-modules gen-esm",
-    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -external-library-path+=node_modules/openfl/dist/openfl.swc -allow-subclass-overrides=true -namespace https://ns.feathersui.com/mxml npm-scripts/mxml-manifest.xml -include-namespaces https://ns.feathersui.com/mxml -output=dist/feathersui-royale-typedefs.swc",
+    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -external-library-path+=node_modules/openfl/dist/openfl.swc -allow-subclass-overrides=true -namespace library://ns.feathersui.com/openfl/mxml npm-scripts/mxml-manifest.xml -include-namespaces library://ns.feathersui.com/openfl/mxml -output=dist/feathersui-royale-typedefs.swc",
     "build-dist": "npm run build-dist:dev && npm run build-dist:prod && npm run build-swc",
     "build-dist:dev": "webpack --config webpack.dev.js",
     "build-dist:prod": "webpack --config webpack.prod.js"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gen-lib": "cd npm-scripts && node generate-modules gen-lib",
     "build-lib": "cd npm-scripts && haxe js-lib.hxml && node generate-modules fix-npm-libs && tsc",
     "build-lib-esm": "cd npm-scripts && node generate-modules gen-esm",
-    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -external-library-path+=node_modules/openfl/dist/openfl.swc -allow-subclass-overrides=true --namespace+=https://ns.feathersui.com/mxml,npm-scripts/manifest.xml -output=dist/feathersui-royale-typedefs.swc",
+    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -external-library-path+=node_modules/openfl/dist/openfl.swc -allow-subclass-overrides=true --namespace+=https://ns.feathersui.com/mxml,npm-scripts/mxml-manifest.xml -output=dist/feathersui-royale-typedefs.swc",
     "build-dist": "npm run build-dist:dev && npm run build-dist:prod && npm run build-swc",
     "build-dist:dev": "webpack --config webpack.dev.js",
     "build-dist:prod": "webpack --config webpack.prod.js"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gen-lib": "cd npm-scripts && node generate-modules gen-lib",
     "build-lib": "cd npm-scripts && haxe js-lib.hxml && node generate-modules fix-npm-libs && tsc",
     "build-lib-esm": "cd npm-scripts && node generate-modules gen-esm",
-    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -external-library-path+=node_modules/openfl/dist/openfl.swc -allow-subclass-overrides=true --namespace+=https://ns.feathersui.com/mxml,npm-scripts/mxml-manifest.xml -output=dist/feathersui-royale-typedefs.swc",
+    "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -external-library-path+=node_modules/openfl/dist/openfl.swc -allow-subclass-overrides=true -namespace https://ns.feathersui.com/mxml npm-scripts/mxml-manifest.xml -include-namespaces https://ns.feathersui.com/mxml -output=dist/feathersui-royale-typedefs.swc",
     "build-dist": "npm run build-dist:dev && npm run build-dist:prod && npm run build-swc",
     "build-dist:dev": "webpack --config webpack.dev.js",
     "build-dist:prod": "webpack --config webpack.prod.js"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build-lib": "cd npm-scripts && haxe js-lib.hxml && node generate-modules fix-npm-libs && tsc",
     "build-lib-esm": "cd npm-scripts && node generate-modules gen-esm",
     "build-swc": "compc -load-config=node_modules/@apache-royale/royale-js/royale-asjs/frameworks/js-config.xml -keep-as3-metadata=JSModule -include-sources=lib -compiler.targets=SWF,JS -warnings=false -external-library-path+=node_modules/openfl/dist/openfl.swc -allow-subclass-overrides=true --namespace+=https://ns.feathersui.com/mxml,npm-scripts/manifest.xml -output=dist/feathersui-royale-typedefs.swc",
-    "build-dist": "npm run build-dist:dev && npm run build-dist:prod",
+    "build-dist": "npm run build-dist:dev && npm run build-dist:prod && npm run build-swc",
     "build-dist:dev": "webpack --config webpack.dev.js",
     "build-dist:prod": "webpack --config webpack.prod.js"
   }


### PR DESCRIPTION
Opening this as https://github.com/apache/royale-compiler/commit/de684f3eb4c65bcaa424e9a5d22d45ced57c7005 allows this to work 

This enables enabling the SWC for Apache Royale, and exposes it to MXML in the `library://ns.feathersui.com/openfl/mxml` namespace.

For proper MXML Support, I was forced to add support for Metadata in AS3ExternsGenerator, I also had to make it so `@:noCompletion` generates [Exclude] and [ExcludeClass] metadata, since the properties `[DefaultProperty]` used had @:noCompletion but had to be available.

Since I had to modify them, I also updated TSExternsGenerator and AS3ExternsGenerator to the latest version in the OpenFL repo.

I updated to node 18 because it seemed 16 was throwing a bunch of errors